### PR TITLE
Feat/minorimprovements

### DIFF
--- a/MySql.Server/Library/MySqlServer.cs
+++ b/MySql.Server/Library/MySqlServer.cs
@@ -17,6 +17,7 @@ namespace MySql.Server
         private string _dataDirectory;
         private string _dataRootDirectory;
         private string _runningInstancesFile;
+        private const string _MYSQLEXE = "mysqld_test.exe";
 
         private int _serverPort = 3306;
         private Process _process;
@@ -175,9 +176,9 @@ namespace MySql.Server
         private void extractMySqlFiles()
         {
             try { 
-                if (!new FileInfo(_mysqlDirectory + "\\mysqld.exe").Exists) {
+                if (!new FileInfo(_mysqlDirectory + "\\" + _MYSQLEXE).Exists) {
                     //Extracting the two MySql files needed for the standalone server
-                    File.WriteAllBytes(_mysqlDirectory + "\\mysqld.exe", Properties.Resources.mysqld);
+                    File.WriteAllBytes(_mysqlDirectory + "\\" + _MYSQLEXE, Properties.Resources.mysqld);
                     File.WriteAllBytes(_mysqlDirectory + "\\errmsg.sys", Properties.Resources.errmsg);
                 }
             }
@@ -221,7 +222,7 @@ namespace MySql.Server
                 "--innodb_data_file_path=ibdata1:10M;ibdata2:10M:autoextend"
             };
 
-            _process.StartInfo.FileName = string.Format("\"{0}\\mysqld.exe\"", _mysqlDirectory);
+            _process.StartInfo.FileName = string.Format("\"{0}\\{1}\"", _mysqlDirectory, _MYSQLEXE);
             _process.StartInfo.Arguments = string.Join(" ", arguments);
             _process.StartInfo.UseShellExecute = false;
             _process.StartInfo.CreateNoWindow = true;

--- a/MySql.Server/MySql.Server.csproj
+++ b/MySql.Server/MySql.Server.csproj
@@ -69,7 +69,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Resource Include="MySqlServer\mysqld.exe">
+    <Resource Include="MySqlServer\mysqld_test.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Resource>
   </ItemGroup>

--- a/MySql.Server/Properties/Resources.resx
+++ b/MySql.Server/Properties/Resources.resx
@@ -122,6 +122,6 @@
     <value>..\MySqlServer\errmsg.sys;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="mysqld" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\MySqlServer\mysqld.exe;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\MySqlServer\mysqld_test.exe;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION
I would like to propose this PR which includes some improvements (in my opinion):

- when removing directories the retry behavior was changed from try-count based to timeout based. The timeout value can be configured by a property (as a Timespan object). I had problems with the old "timeout" when testing on a machine which was under heavy load.
- some errors that were logged and swallowed before now do throw. In my opinion those errors should be result in failed tests
- changed the name of the MySQL executalbe from `mysqld.exe` to `mysqld_test.exe` so it is easy to distinguish from a real mysql daemon